### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+The Jenkins project takes security seriously.
+We make every possible effort to ensure users can adequately secure their automation infrastructure.
+To that end, we work with Jenkins core and plugin developers, as well as security researchers, to fix security vulnerabilities in Jenkins in a timely manner, and to improve the security of Jenkins in general.
+
+## Reporting Security Vulnerabilities
+
+Please report security vulnerabilities in the Jenkins issue tracker under the [SECURITY project](https://issues.jenkins-ci.org/browse/SECURITY).
+This project is configured in such a way that only the reporter and the security team can see the details.
+By restricting access to this potentially sensitive information, we can work on a fix and deliver it before the method of attack becomes well-known.
+
+If you are unable to report using our issue tracker, you can also send your report to the private Jenkins security team mailing list: `jenkinsci-cert@googlegroups.com`
+
+The Jenkins security team will then file an issue on your behalf, and will work with the maintainers of the affected component(s) to get the issue resolved.
+
+## Learn More
+
+For further details about our scope, issue handling process, or disclosure process, see [Reporting Security Vulnerabilities on jenkins.io](https://jenkins.io/security/reporting/).


### PR DESCRIPTION
A subset of https://jenkins.io/security/#reporting-vulnerabilities and https://jenkins.io/security/reporting/

Docs:

* https://help.github.com/en/articles/creating-a-default-community-health-file-for-your-organization
* https://help.github.com/en/articles/adding-a-security-policy-to-your-repository