### PR TITLE
Release Drafter: Use multi-labels

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -10,20 +10,16 @@ categories:
     label: removed
   - title: ⚠️ Deprecated
     label: deprecated
-  # Various tags are used in the repositories, https://github.com/toolmantim/release-drafter/issues/218
   - title: 🚀 New features and improvements
-    label: enhancement
-  - title: 🚀 New features and improvements
-    label: feature
-  # Various tags are used in the repositories, https://github.com/toolmantim/release-drafter/issues/218
+    labels: 
+      - enhancement
+      - feature
   - title: 🐛 Bug Fixes
-    label: bug
-  - title: 🐛 Bug Fixes
-    label: fix
-  - title: 🐛 Bug Fixes
-    label: bugfix
-  - title: 🐛 Bug Fixes
-    label: regression  
+    labels: 
+      - bug
+      - bugfix
+      - regression
+      - fix
   - title: 📝 Documentation updates
     label: documentation
   # Default label used by Dependabot
@@ -35,7 +31,9 @@ categories:
   - title: 🚦 Internal changes
     label: internal
   - title: 🚦 Tests
-    label: test
+    labels: 
+      - test
+      - tests
 exclude-labels:
   - reverted
   - no-changelog
@@ -64,4 +62,3 @@ replacers:
     replace: 'Jenkinsfile Runner'
   - search: 'CWP'
     replace: 'Custom WAR Packager'
- 


### PR DESCRIPTION
This change adopts a patch for https://github.com/toolmantim/release-drafter/issues/218 , mostly for refactoring purposes . Also added the `tests` label