### PR TITLE
Release Drafter: Change the defaults in `name-template` and `tag-template` to target the two-digit format

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,6 @@
 # Configuration for Release Drafter: https://github.com/toolmantim/release-drafter
-name-template: $NEXT_PATCH_VERSION
-tag-template: $NEXT_PATCH_VERSION
+name-template: $NEXT_MINOR_VERSION
+tag-template: $NEXT_MINOR_VERSION
 # Uses a more common 2-digit versioning in Jenkins plugins. Can be replaced by semver: $MAJOR.$MINOR.$PATCH
 version-template: $MAJOR.$MINOR
 


### PR DESCRIPTION
This change improves the formatting of releases for two-digit versions when `PATCH_NUMBER` is not set.  Currently Release Drafter proposes the same version as before for the most of the plugins. Our documentation recommends setting the `tag-template`, so it should be a safe change

Before:

![minorVersion](https://user-images.githubusercontent.com/3000480/61108605-07cc2080-a483-11e9-8ff8-9f3bd8634d55.PNG)
