### PR TITLE
Create a default SUPPORT page for Jenkins

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,13 @@
+Getting support for Jenkins
+===========================
+
+Jenkins is a community-driven project, and it does not provide user support in common means.
+Nevertheless, there is an active community which might be able to help with the issues you experience.
+The [Jenkins JIRA](https://issues.jenkins-ci.org/secure/Dashboard.jspa) is **NOT** a support site. 
+If you need assistance or have general questions, visit us in [chat](https://jenkins.io/chat/), or email one of the user [mailing lists](https://jenkins.io/mailing-lists/).
+Please be aware that most of the Jenkins components are maintained by volunteers. 
+This means, there is no guarantee of the timely response and/or issue resolution.
+
+If you want to get a commercial support for Jenkins with SLA,
+there are companies which offer it.
+Check out [this Wiki page](https://wiki.jenkins.io/display/JENKINS/Commercial+Support) for the list.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -8,7 +8,7 @@ If you need assistance or have general questions, visit us in [chat](https://jen
 Also check out the main component's page for specific communication channel references.
 
 Please be aware that most of the Jenkins components are maintained by volunteers. 
-This means, there is no guarantee of the timely response and/or issue resolution.
-If you want to get a commercial support for Jenkins with SLA,
+This means, there is no guarantee of a timely response or issue resolution.
+If you want commercial support for Jenkins,
 there are companies which offer it.
-Check out [this Wiki page](https://wiki.jenkins.io/display/JENKINS/Commercial+Support) for the list.
+See [this Wiki page](https://wiki.jenkins.io/display/JENKINS/Commercial+Support).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -5,9 +5,10 @@ Jenkins is a community-driven project, and it does not provide user support in c
 Nevertheless, there is an active community which might be able to help with the issues you experience.
 The [Jenkins JIRA](https://issues.jenkins-ci.org/secure/Dashboard.jspa) is **NOT** a support site. 
 If you need assistance or have general questions, visit us in [chat](https://jenkins.io/chat/), or email one of the user [mailing lists](https://jenkins.io/mailing-lists/).
+Also check out the main component's page for specific communication channel references.
+
 Please be aware that most of the Jenkins components are maintained by volunteers. 
 This means, there is no guarantee of the timely response and/or issue resolution.
-
 If you want to get a commercial support for Jenkins with SLA,
 there are companies which offer it.
 Check out [this Wiki page](https://wiki.jenkins.io/display/JENKINS/Commercial+Support) for the list.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,7 +1,7 @@
 Getting support for Jenkins
 ===========================
 
-Jenkins is a community-driven project, and it does not provide user support in common means.
+Jenkins is a community-driven project, and it does not provide user support in the common meaning.
 Nevertheless, there is an active community which might be able to help with the issues you experience.
 The [Jenkins JIRA](https://issues.jenkins-ci.org/secure/Dashboard.jspa) is **NOT** a support site. 
 If you need assistance or have general questions, visit us in [chat](https://jenkins.io/chat/), or email one of the user [mailing lists](https://jenkins.io/mailing-lists/).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -7,8 +7,9 @@ The [Jenkins JIRA](https://issues.jenkins-ci.org/secure/Dashboard.jspa) is **NOT
 If you need assistance or have general questions, visit us in [chat](https://jenkins.io/chat/), or email one of the user [mailing lists](https://jenkins.io/mailing-lists/).
 Also check out the main component's page for specific communication channel references.
 
-Please be aware that most of the Jenkins components are maintained by volunteers. 
-This means, there is no guarantee of a timely response or issue resolution.
+Please be aware that most Jenkins components are maintained by volunteers. 
+This means there is no guarantee of a timely response or issue resolution.
 If you want commercial support for Jenkins,
 there are companies which offer it.
-See [this Wiki page](https://wiki.jenkins.io/display/JENKINS/Commercial+Support).
+See the list on [this Wiki page](https://wiki.jenkins.io/display/JENKINS/Commercial+Support).
+Note that this list should not be viewed as endorsement by the Jenkins project, the list is provided for reference.


### PR DESCRIPTION
See https://help.github.com/en/articles/adding-support-resources-to-your-project

This change adds some wording about Support for Jenkins. A reference to this page will pop-up in the GitHub issues creation dialog, and hence it may help for components like https://github.com/jenkinsci/docker and https://github.com/jenkinsci/configuration-as-code-plugin which experience a considerable user support request traffic.

The feasibility of such change and the text are up for the discussion, I just assembled few usual response templates from Jenkins JIRA.

 