### PR TITLE
Release Drafter: Add a category for breaking changes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -9,7 +9,6 @@ categories:
   - title: :boom: Breaking changes
     labels: 
       - breaking
-      - breaking-change
   - title: 🚨 Removed
     label: removed
   - title: ⚠️ Deprecated

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,6 +6,10 @@ version-template: $MAJOR.$MINOR
 
 # Emoji reference: https://gitmoji.carloscuesta.me/
 categories:
+  - title: :boom: Breaking changes
+    labels: 
+      - breaking
+      - breaking-change
   - title: 🚨 Removed
     label: removed
   - title: ⚠️ Deprecated


### PR DESCRIPTION
Used it in https://github.com/jenkins-infra/pipeline-library/releases/tag/1.2.0 and https://github.com/jenkinsci/configuration-as-code-plugin/releases/tag/configuration-as-code-1.25 . I hope it will not be THAT opular, but I suggest making it a part of the default package. It will be listed as a first entry
