### PR TITLE
Escape the "Breaking changes" title with a custom symbol

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,7 +6,7 @@ version-template: $MAJOR.$MINOR
 
 # Emoji reference: https://gitmoji.carloscuesta.me/
 categories:
-  - title: :boom: Breaking changes
+  - title: ":boom: Breaking changes"
     labels: 
       - breaking
   - title: 🚨 Removed


### PR DESCRIPTION
As it was reported by @jglick , Release Drafter looks to be broken. AFAICT it is caused by #15 where I messed up the syntax.

I will add CI to the repository to avoid such issues in the future
