### PR TITLE
Hacktoberfest - Merge the "Internal" category into "Maintenance"

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -29,10 +29,9 @@ categories:
   - title: 📦 Dependency updates
     label: dependencies
   - title: 👻 Maintenance
-    label: chore
-  # TODO: consider merging category or changing emojis
-  - title: 🚦 Internal changes
-    label: internal
+    labels: 
+      - chore
+      - internal
   - title: 🚦 Tests
     labels: 
       - test


### PR DESCRIPTION
After some Release Drafter I actually do not see any component using both categories. So I suggest just merging them to keep the things simple