### PR TITLE
Create a global CONTRIBUTING page for repositories which do not override it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing to Jenkins
+
+[![Contributing](https://img.shields.io/badge/contributing-guidelines-blue)](https://jenkins.io/participate/)
+
+In the Jenkins project we appreciate any kind of contributions: code, documentation, design, etc.
+Any contribution counts, and the size does not matter!
+Check out [this page](https://jenkins.io/participate/) for more information and links!
+
+Many plugins and components also define their own contributing guidelines and communication channels. 
+There is also a big number of [mailing lists](https://jenkins.io/mailing-lists/) and [chats](https://jenkins.io/chat/).
+
+| WARNING: This is a default CONTRIBUTING page for all repositories in Jenkins. It might be overridden in repositories, and contributing guidelines maybe also defined in other places README. |
+| --- |
+
+## Newcomers
+
+If you are a newcomer contributor and have any questions, please do not hesitate to ask in the [Newcomers Gitter channel](https://gitter.im/jenkinsci/newcomer-contributors).
+
+## Useful links
+
+* [Jenkins: Participate and Contribute](https://jenkins.io/participate/)
+* [Slides: Contributing to Jenkins - it is all about you](https://docs.google.com/presentation/d/1JHgVzWZAx95IsUAZp8OoyCQGGkrCjzUd7eblwd1Y-hA/edit?usp=sharing)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,5 @@
 # Contributing to Jenkins
 
-[![Contributing](https://img.shields.io/badge/contributing-guidelines-blue)](https://jenkins.io/participate/)
 
 In the Jenkins project we appreciate any kind of contributions: code, documentation, design, etc.
 Any contribution counts, and the size does not matter!
@@ -9,7 +8,7 @@ Check out [this page](https://jenkins.io/participate/) for more information and 
 Many plugins and components also define their own contributing guidelines and communication channels. 
 There is also a big number of [mailing lists](https://jenkins.io/mailing-lists/) and [chats](https://jenkins.io/chat/).
 
-| WARNING: This is a default CONTRIBUTING page for all repositories in Jenkins. It might be overridden in repositories, and contributing guidelines maybe also defined in other places README. |
+| WARNING: This is a default CONTRIBUTING page for all repositories in Jenkins. Every plugin/component is its own sub-project which may deviate in its rules. Guidelines and channel links in repository CONTRIBUTING/README pages, if any, take precedence over this page. |
 | --- |
 
 ## Newcomers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Check out [this page](https://jenkins.io/participate/) for more information and 
 Many plugins and components also define their own contributing guidelines and communication channels. 
 There is also a big number of [mailing lists](https://jenkins.io/mailing-lists/) and [chats](https://jenkins.io/chat/).
 
-| WARNING: This is a default CONTRIBUTING page for all repositories in Jenkins. Every plugin/component is its own sub-project which may deviate in its rules. Guidelines and channel links in repository CONTRIBUTING/README pages, if any, take precedence over this page. |
+| NOTE: This is a default CONTRIBUTING page for all repositories in Jenkins. Every plugin/component is its own sub-project which may deviate in its rules. Guidelines and channel links in repository CONTRIBUTING/README pages, if any, take precedence over this page. |
 | --- |
 
 ## Newcomers


### PR DESCRIPTION
First draft of the global Contributing page for those repositories which do not have it