### PR TITLE
Release Drafter: Show dependencies before the documentation by default

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -22,12 +22,12 @@ categories:
       - bug
       - fix
       - bugfix
-      - regression  
-  - title: 📝 Documentation updates
-    label: documentation
-  # Default label used by Dependabot
+      - regression
+   # Default label used by Dependabot
   - title: 📦 Dependency updates
     label: dependencies
+  - title: 📝 Documentation updates
+    label: documentation
   - title: 👻 Maintenance
     labels: 
       - chore


### PR DESCRIPTION
Dependencies may include user-facing changes in the packages, so I would rather put them ahead of the documentation updates