### PR TITLE
Release Drafter: Add a category for Developer changes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -23,7 +23,10 @@ categories:
       - fix
       - bugfix
       - regression
-   # Default label used by Dependabot
+  - title: ":construction_worker: Changes for plugin developers"
+    labels:
+      - developer 
+  # Default label used by Dependabot
   - title: 📦 Dependency updates
     label: dependencies
   - title: 📝 Documentation updates


### PR DESCRIPTION
With this change maintainers will be able to chose between `enhancement` and `developer` labels depending on their process. Mostly needed for the Jenkins core at the moment