### PR TITLE
Fix minor README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ See [this thread](https://groups.google.com/forum/#!topic/jenkinsci-dev/dOs8YRQw
 
 Currently the following features are configured globally:
 
-* [Code of Conduct](./CODE_OF_CONDUCT.md) - Automatic referncing of Code of Conduct when creating new issues or pull requests
+* [Code of Conduct](./CODE_OF_CONDUCT.md) - Automatic referencing of Code of Conduct when creating new issues or pull requests
   ([more info](https://help.github.com/en/articles/creating-a-default-community-health-file-for-your-organization))
-* [Security Links](./SECURITY.md) - Automatic referncing of Jenkins security policies when creating new issues or pull requests
+* [Security Links](./SECURITY.md) - Automatic referencing of Jenkins security policies when creating new issues or pull requests
   ([more info](https://help.github.com/en/articles/creating-a-default-community-health-file-for-your-organization))
 * [Release Drafter](./.github/release-drafter.adoc) - Changelog automation
 
@@ -19,12 +19,12 @@ Currently the following features are configured globally:
 
 The following channels can be used:
 
-* JIRA - Create an ticket in [Jenkins JIRA](https://issues.jenkins-ci.org) (project=`INFRA`, component=`github`)
+* Jira - Create a ticket in [Jenkins Jira](https://issues.jenkins-ci.org) (project=`INFRA`, component=`github`)
 * Mailing lists - Use the [Jenkins Infrastructure mailing list](https://jenkins.io/mailing-lists/#infra-lists-jenkins-ci-org)
 * IRC - Use the [#jenkins-infra](https://jenkins.io/chat/#jenkins-infra) channel on Freenode
 * GitHub - Mention [@jenkinsci/github-admins](https://github.com/orgs/jenkinsci/teams/github-admins) in pull requests or GitHub issues. Available to org members only
 
-Jenkins JIRA and mailing lists are the recommended ways to send queries.
+Jenkins Jira and mailing lists are the recommended ways to send queries.
 
 ## Contributing
 


### PR DESCRIPTION
Fix some minor typos. (And note, Atlassian now brands JIRA as Jira, so just changed those).

Love this repo as a concept for other open source projects/orgs.