### PR TITLE
Add default organisation-wide issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-report-bug.md
+++ b/.github/ISSUE_TEMPLATE/1-report-bug.md
@@ -1,0 +1,50 @@
+---
+name: "🐛 Bug report"
+labels: bug
+about: Create a bug report to help us improve
+---
+
+<!--
+SECURITY ISSUES:
+Never report security issues on GitHub or other public channels (Gitter/Twitter/etc.)
+Follow these instruction to report security issues: https://www.jenkins.io/security/#reporting-vulnerabilities
+-->
+
+### Version report
+
+Jenkins and plugins versions report:
+
+<!-- paste below the version report from https://www.jenkins.io/doc/book/system-administration/diagnosing-errors/#how-to-report-a-bug -->
+
+```
+Copy/paste here....
+```
+
+- What Operating System are you using (both controller, and any agents involved in the problem)?
+
+```
+Paste here
+```
+
+### Reproduction steps
+
+<!--
+- Write bullet-point reproduction steps.
+- Be explicit about any relevant configuration, jobs, build history, user accounts, etc., redacting confidential information as needed.
+- The best reproduction steps start with a clean Jenkins install, perhaps a `docker run` command if possible.
+- Use screenshots where appropriate, copy textual output otherwise. When in doubt, do both.
+- Include relevant logs, debug if needed - https://www.jenkins.io/doc/book/system-administration/viewing-logs/
+-->
+
+- Step 1...
+- Step 2...
+
+### Results
+
+Expected result:
+
+<!-- What was your expected result? -->
+
+Actual result:
+
+<!-- What was the actual result? -->

--- a/.github/ISSUE_TEMPLATE/2-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.md
@@ -1,0 +1,13 @@
+---
+name: "🚀 Feature request"
+labels: feature
+about: I have a suggestion
+---
+
+### Dependencies
+
+<!-- Link here any upstream changes that might be relevant to this request --->
+
+### Feature Request
+
+<!-- Describe your feature request here -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+<!-- Please describe your pull request here. -->
+
+- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
+- [ ] Ensure that the pull request title represents the desired changelog entry
+- [ ] Please describe what you did
+- [ ] Link to relevant issues in GitHub or Jira
+- [ ] Link to relevant pull requests, esp. upstream and downstream changes
+- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
+
+<!--
+Put an `x` into the [ ] to show you have filled the information
+-->

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Currently the following features are configured globally:
 
 * [Code of Conduct](./CODE_OF_CONDUCT.md) - Automatic referencing of Code of Conduct when creating new issues or pull requests
   ([more info](https://help.github.com/en/articles/creating-a-default-community-health-file-for-your-organization))
+* [Issue Templates](./ISSUE_TEMPLATE/) - templates for newly created Issues and Feature Requests.
+* [Pull Request Template](./pull_request_template.md) - template for pull request creation.
 * [Security Links](./SECURITY.md) - Automatic referencing of Jenkins security policies when creating new issues or pull requests
   ([more info](https://help.github.com/en/articles/creating-a-default-community-health-file-for-your-organization))
 * [Release Drafter](./.github/release-drafter.adoc) - Changelog automation


### PR DESCRIPTION
As discussed on jenkins-dev, please review @jenkinsci/github-admins 