### PR TITLE
Use genuine emoji consistently

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,12 +6,12 @@ version-template: $MAJOR.$MINOR
 
 # Emoji reference: https://gitmoji.carloscuesta.me/
 categories:
-  - title: ":boom: Breaking changes"
+  - title: 💥 Breaking changes
     labels: 
       - breaking
   - title: 🚨 Removed
     label: removed
-  - title: ":tada: Major features and improvements"
+  - title: 🎉 Major features and improvements
     labels:
       - major-enhancement
       - major-rfe
@@ -31,7 +31,7 @@ categories:
       - fix
       - bugfix
       - regression
-  - title: ":construction_worker: Changes for plugin developers"
+  - title: 👷 Changes for plugin developers
     labels:
       - developer 
   # Default label used by Dependabot


### PR DESCRIPTION
Most of the Release Drafter categories were using Unicode emoji, but three were using GitHub-Flavored Markdown equivalents, for no reason I could see.

Stumbled across this working on https://github.com/jenkins-infra/jenkins-maven-cd-action/issues/1.