### PR TITLE
Release drafter 5.14 - add autolabeler definition

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -81,7 +81,7 @@ replacers:
     replace: '@dependabot'
 
 autolabeler:
-  - label: 'chore'
+  - label: 'documentation'
     files:
       - '*.md'
     branch:
@@ -96,4 +96,3 @@ autolabeler:
       - '/feature\/.+/'
     body:
       - '/JENKINS-[0-9]{1,4}/'
-

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -79,3 +79,21 @@ replacers:
     replace: 'Custom WAR Packager'
   - search: '@dependabot-preview'
     replace: '@dependabot'
+
+autolabeler:
+  - label: 'chore'
+    files:
+      - '*.md'
+    branch:
+      - '/docs{0,1}\/.+/'
+  - label: 'bug'
+    branch:
+      - '/fix\/.+/'
+    title:
+      - '/fix/i'
+  - label: 'enhancement'
+    branch:
+      - '/feature\/.+/'
+    body:
+      - '/JENKINS-[0-9]{1,4}/'
+


### PR DESCRIPTION
Auto-label issues based on branches/titles/body.
https://github.com/release-drafter/release-drafter/releases/tag/v5.14.0

Ready for review: @jenkinsci/github-admins