### PR TITLE
Update issue tracker references to use latest URL

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -60,13 +60,13 @@ template: |
 
 replacers:
   - search: '/\[*JENKINS-(\d+)\]*\s*-*\s*/g'
-    replace: '[JENKINS-$1](https://issues.jenkins-ci.org/browse/JENKINS-$1) - '
+    replace: '[JENKINS-$1](https://issues.jenkins.io/browse/JENKINS-$1) - '
   - search: '/\[*INFRA-(\d+)\]*\s*-*\s*/g'
-    replace: '[INFRA-$1](https://issues.jenkins-ci.org/browse/INFRA-$1) - '
+    replace: '[INFRA-$1](https://issues.jenkins.io/browse/INFRA-$1) - '
   - search: '/\[*WEBSITE-(\d+)\]*\s*-*\s*/g'
-    replace: '[WEBSITE-$1](https://issues.jenkins-ci.org/browse/WEBSITE-$1) - '
+    replace: '[WEBSITE-$1](https://issues.jenkins.io/browse/WEBSITE-$1) - '
   - search: '/\[*HOSTING-(\d+)\]*\s*-*\s*/g'
-    replace: '[HOSTING-$1](https://issues.jenkins-ci.org/browse/HOSTING-$1) - '  
+    replace: '[HOSTING-$1](https://issues.jenkins.io/browse/HOSTING-$1) - '
   # TODO(oleg_nenashev): Find a better way to reference issues
   - search: '/\[*SECURITY-(\d+)\]*\s*-*\s*/g'
     replace: '[SECURITY-$1](https://jenkins.io/security/advisories/) - '

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@
 
 **Never report security issues on GitHub, public Jira issues or other public channels (Gitter/Twitter/etc.), 	
 follow the instruction from [Jenkins Security](https://www.jenkins.io/security/#reporting-vulnerabilities) to 	
-report it on [Jenkins Jira](https://issues.jenkins-ci.org)**	
+report it on [Jenkins Jira](https://issues.jenkins.io/)**
 
 In the Jenkins project we appreciate any kind of contributions: code, documentation, design, etc.
 Any contribution counts, and the size does not matter!

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Currently the following features are configured globally:
 
 The following channels can be used:
 
-* Jira - Create a ticket in [Jenkins Jira](https://issues.jenkins-ci.org) (project=`INFRA`, component=`github`)
+* Jira - Create a ticket in [Jenkins Jira](https://issues.jenkins.io/) (project=`INFRA`, component=`github`)
 * Mailing lists - Use the [Jenkins Infrastructure mailing list](https://jenkins.io/mailing-lists/#infra-lists-jenkins-ci-org)
 * IRC - Use the [#jenkins-infra](https://jenkins.io/chat/#jenkins-infra) channel on Freenode
 * GitHub - Mention [@jenkinsci/github-admins](https://github.com/orgs/jenkinsci/teams/github-admins) in pull requests or GitHub issues. Available to org members only

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ To that end, we work with Jenkins core and plugin developers, as well as securit
 
 ## Reporting Security Vulnerabilities
 
-Please report security vulnerabilities in the Jenkins issue tracker under the [SECURITY project](https://issues.jenkins-ci.org/browse/SECURITY).
+Please report security vulnerabilities in the Jenkins issue tracker under the [SECURITY project](https://issues.jenkins.io/browse/SECURITY).
 This project is configured in such a way that only the reporter and the security team can see the details.
 By restricting access to this potentially sensitive information, we can work on a fix and deliver it before the method of attack becomes well-known.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -3,7 +3,7 @@ Getting support for Jenkins
 
 Jenkins is a community-driven project, and it does not provide user support in the common meaning.
 Nevertheless, there is an active community which might be able to help with the issues you experience.
-The [Jenkins JIRA](https://issues.jenkins-ci.org/secure/Dashboard.jspa) is **NOT** a support site. 
+The [Jenkins Jira](https://issues.jenkins.io/) is **NOT** a support site.
 If you need assistance or have general questions, visit us in [chat](https://jenkins.io/chat/), or email one of the user [mailing lists](https://jenkins.io/mailing-lists/).
 Also check out the main component's page for specific communication channel references.
 


### PR DESCRIPTION
Updating issue tracker references from the old URL (`issues.jenkins-ci.org`) to the new URL (`issues.jenkins.io`).