### PR TITLE
Update setup-java to v2

### DIFF
--- a/workflow-templates/cd.yaml
+++ b/workflow-templates/cd.yaml
@@ -47,8 +47,9 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set up JDK 8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
+        distribution: 'adopt'
         java-version: 1.8
     - name: Release
       uses: jenkins-infra/jenkins-maven-cd-action@v1.1.0


### PR DESCRIPTION
https://github.com/jenkinsci/azure-artifact-manager-plugin/pull/14

See https://github.com/actions/setup-java/blob/main/docs/adrs/0000-v2-setup-java.md

Note: this has a breaking change in it, distribution is now required, and worse our repoes only using github actions for CD don't test the action on CI

@jenkinsci/github-admins 