### PR TITLE
Add Discourse and Mailing lists to the default issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discourse Forum
+    url: https://community.jenkins.io/
+    about: Please ask and answer questions here
+  - name: Mailing lists
+    url: https://www.jenkins.io/mailing-lists/
+    about: You can also raise a question in one of the user or developer mailing lists
+  

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Discourse Forum
+  - name: Community forum
     url: https://community.jenkins.io/
     about: Please ask and answer questions here
   - name: Mailing lists


### PR DESCRIPTION
If merged, standard issue creation dialogs will also include links to Discourse and Mailing lists