### PR TITLE
Remove unreferenced link from org profile README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -13,5 +13,3 @@ See also our [Project Governance and Values](https://www.jenkins.io/project/gove
 This is the main GitHub organization of the Jenkins community.
 It includes repositories of the [Jenkins core](https://github.com/jenkinsci/jenkins), plugins, libraries and developer tools.
 You can learn more about the project structure on the [website](https://www.jenkins.io/participate/code/).
-
-[ButlerImage]: https://www.jenkins.io/sites/default/files/jenkins_logo.png


### PR DESCRIPTION
ButlerImage is no longer in use since the image was removed in https://github.com/jenkinsci/.github/pull/58/commits/68eb2281a77097d264c62352b7077f068bbe7dc5

**Related PR:** #58