### PR TITLE
Exchange `adopt` with `temurin` in CD example

### DIFF
--- a/workflow-templates/cd.yaml
+++ b/workflow-templates/cd.yaml
@@ -47,9 +47,9 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set up JDK 8
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v2.5.0
       with:
-        distribution: 'adopt'
+        distribution: temurin
         java-version: 8
     - name: Release
       uses: jenkins-infra/jenkins-maven-cd-action@v1.2.0


### PR DESCRIPTION
AdoptOpenJDK has moved to the Eclipse Foundation and does now deploy their OpenJDK builds under Adoptium.
If you use `adopt` in your runner files, you get Java 8.0.292+1, the last build under AdoptOpenJDK, where Temurin serves 8.0.312+7, the actual latest build of Java 8.
A minor change but, but ensures your runner uses an up to date version of Java.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did