### PR TITLE
Remove category to make this more discoverable

### DIFF
--- a/workflow-templates/jenkins-security-scan.properties.json
+++ b/workflow-templates/jenkins-security-scan.properties.json
@@ -2,9 +2,6 @@
     "name": "Jenkins Security Scan",
     "description": "Code scanner identifying common Jenkins plugin development pitfalls. Learn more: jenkins.io/redirect/jenkins-security-scan",
     "iconName": "jenkins-security",
-    "categories": [
-        "Java"
-    ],
     "filePatterns": [
         "^pom[.]xml$",
         "^build[.]gradle$"


### PR DESCRIPTION
Right now, this gets lost in the generic Java-related workflows being offered when linguist detects the plugin is written in Java:

> <img width="1184" alt="Screenshot 2022-02-22 at 12 52 16" src="https://user-images.githubusercontent.com/1831569/155126995-7035db5c-f6f7-48e3-a7a9-7770fde753c1.png">

Without an explicit category, it'll be part of the "By Jenkins" section afterwards:

> <img width="639" alt="Screenshot 2022-02-22 at 12 53 20" src="https://user-images.githubusercontent.com/1831569/155127101-b7addc32-bbba-4ca4-8941-6c4be4322cc4.png">

There seems to be no category for analysis/security. Only linguist categories and "Automation", "Deployment", and "Continuous Integration" seem to be possible.
 
While slightly further down on the page, the smaller number of workflows available should make it easier to find. It's also consistent with existing docs at https://www.jenkins.io/doc/developer/security/scan/ and does not depend on what linguist says is the predominant language of the repo.