### PR TITLE
Bump `actions/setup-java` to 3.0.0

### DIFF
--- a/workflow-templates/cd.yaml
+++ b/workflow-templates/cd.yaml
@@ -47,7 +47,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set up JDK 8
-      uses: actions/setup-java@v2.5.0
+      uses: actions/setup-java@v3.0.0
       with:
         distribution: temurin
         java-version: 8


### PR DESCRIPTION
Pretty minor change that maintains new CD configurations. Dependabot takes care of the existing ones.

setup-java 2.x uses Node 12, which is EOL by the 30th of April 2022. 3x uses Node 16, which is EOL by the 30th of April 2024.