### PR TITLE
Bump jenkins-security-scan from v1 to v2

### DIFF
--- a/workflow-templates/jenkins-security-scan.yaml
+++ b/workflow-templates/jenkins-security-scan.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   security-scan:
-    uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v1
+    uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
     with:
       java-cache: '' # Optionally enable use of a build dependency cache. Specify 'maven' or 'gradle' as appropriate.
       java-version: 11 # What version of Java to set up for the build.


### PR DESCRIPTION
A bit earlier than expected 😅 Unfortunately, the results are now necessarily associated with a "tool name", when previously they were not. If I had just updated v1, it would result in useless comparison diffs in PRs updated after the default branch, considering all warnings new.

Release notes: https://github.com/jenkins-infra/jenkins-security-scan/releases/tag/v2