### PR TITLE
Add release-drafter as workflow template

### DIFF
--- a/workflow-templates/release-drafter.properties.json
+++ b/workflow-templates/release-drafter.properties.json
@@ -1,0 +1,5 @@
+{
+  "name": "Publish changelogs to GitHub Releases",
+  "description": "Assemble a changelog based on pull requests with matching labels.",
+  "iconName": "jenkins"
+}

--- a/workflow-templates/release-drafter.properties.json
+++ b/workflow-templates/release-drafter.properties.json
@@ -1,5 +1,5 @@
 {
   "name": "Publish changelogs to GitHub Releases",
-  "description": "Assemble a changelog based on pull requests with matching labels.",
+  "description": "Assemble a changelog based on pull requests with matching labels, if you don't publish releases via CD.",
   "iconName": "jenkins"
 }

--- a/workflow-templates/release-drafter.yaml
+++ b/workflow-templates/release-drafter.yaml
@@ -1,0 +1,17 @@
+# Note: additional setup is required, see https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
+
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - $default-branch
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5.18.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/workflow-templates/release-drafter.yaml
+++ b/workflow-templates/release-drafter.yaml
@@ -12,6 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5.18.1
+      - uses: release-drafter/release-drafter@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The idea is to promote the usage of release drafter better, by simply adding it right next to the existing workflows, you can simply install with a few clicks.
This somewhat of amends my [conversation with Jesse](https://github.com/jenkins-infra/helpdesk/issues/2799#issuecomment-1054588241) on my helpdesk ticket, to provide a simple way for the app users of RD to switch over to the workflow, if they aren't using CD yet.

I was testing this workflow template in https://github.com/NotMyFault-org/.github/tree/main/workflow-templates and it currently renders as
![](https://i.imgur.com/T8ugshw.png)