### PR TITLE
Drop permissions for jenkins-security-scan template

### DIFF
--- a/workflow-templates/jenkins-security-scan.yaml
+++ b/workflow-templates/jenkins-security-scan.yaml
@@ -7,6 +7,11 @@ on:
     types: [ opened, synchronize, reopened ]
   workflow_dispatch:
 
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+
 jobs:
   security-scan:
     uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2


### PR DESCRIPTION
This declares the permissions needed for the called workflow, so this can also run even if the default `GITHUB_TOKEN` permissions for the repository are read-only:

> <img width="1220" alt="Screenshot" src="https://user-images.githubusercontent.com/1831569/158603461-963e1f82-5380-42c1-88c1-c3bfb4331e71.png">

While the workflow does not need the `read` permissions for public repositories, it is not possible to call the reusable workflow (that is written to support private repos) without these.

Origin branch, please delete on merge.