### PR TITLE
Add `regression-fix` label

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -32,6 +32,7 @@ categories:
       - fix
       - bugfix
       - regression
+      - regression-fix
   - title: 👷 Changes for plugin developers
     labels:
       - developer 


### PR DESCRIPTION
Core and the changelog generator use this label to pick up regression fixes. Core PRs require manual fixup, as seen on the draft for 2.344.
The change proposed sorts these PRs accordingly into the generated changelog.