### PR TITLE
Use the reusable workflow as a template

### DIFF
--- a/workflow-templates/cd.yaml
+++ b/workflow-templates/cd.yaml
@@ -8,54 +8,8 @@ on:
       - completed
 
 jobs:
-  validate:
-    runs-on: ubuntu-latest
-    outputs:
-      should_release: ${{ steps.verify-ci-status.outputs.result == 'success' && steps.interesting-categories.outputs.interesting == 'true' }}
-    steps:
-      - name: Verify CI status
-        uses: jenkins-infra/verify-ci-status-action@v1.2.0
-        id: verify-ci-status
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          output_result: true
-
-      - name: Release Drafter
-        uses: release-drafter/release-drafter@v5
-        if: steps.verify-ci-status.outputs.result == 'success'
-        with:
-          name: next
-          tag: next
-          version: next
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check interesting categories
-        uses: jenkins-infra/interesting-category-action@v1.1.0
-        id: interesting-categories
-        if: steps.verify-ci-status.outputs.result == 'success'
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  release:
-    runs-on: ubuntu-latest
-    needs: [validate]
-    if: needs.validate.outputs.should_release == 'true'
-    steps:
-    - name: Check out
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-
-    - name: Set up JDK 8
-      uses: actions/setup-java@v3
-      with:
-        distribution: temurin
-        java-version: 8
-
-    - name: Release
-      uses: jenkins-infra/jenkins-maven-cd-action@v1.3.0
-      with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-        MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
+  maven-cd:
+    uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v1
+    secrets:
+      MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+      MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}


### PR DESCRIPTION
This greatly simplifies cd workflow for the end user 😅 

Tested in https://github.com/jenkinsci/jenkins-infra-test-plugin/commit/49b5815e8158d5e5db9ee94039f23d12c1a7e63c

cc @jglick @timja 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
