### PR TITLE
Add initial `comment-ops` config, (reviewer only)

### DIFF
--- a/.github/comment-ops.yml
+++ b/.github/comment-ops.yml
@@ -1,0 +1,3 @@
+commands:
+  reviewer:
+    enabled: true


### PR DESCRIPTION
With https://github.com/timja/github-comment-ops/issues/69 being closed, all commands will be off by default.

This enables reviewer globally.

Once there's more permission control I plan to add labels as well and then people can opt out of that, but I don't think this one will be contentious