### PR TITLE
Add Hacktoberfest info

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -25,4 +25,4 @@ You can learn more about the project structure on the [website](https://www.jenk
 <br/>
 
 The Jenkins community is participating in Hacktoberfest again, and we are looking for contributors and maintainers who want to join us in October!  
-Click [here](https://www.jenkins.io/events/hacktoberfest/) to learn more about this year's Hacktoberfest, and how to make your contributions towards the Jenkins project 🎉
+[Learn more about this year's Hacktoberfest](https://www.jenkins.io/events/hacktoberfest/), and how to make your contributions towards the Jenkins project 🎉

--- a/profile/README.md
+++ b/profile/README.md
@@ -14,7 +14,7 @@ This is the main GitHub organization of the Jenkins community.
 It includes repositories of the [Jenkins core](https://github.com/jenkinsci/jenkins), plugins, libraries and developer tools.
 You can learn more about the project structure on the [website](https://www.jenkins.io/participate/code/).
 
-# Hacktoberfest
+## Hacktoberfest
 
 <a href="https://www.jenkins.io/events/hacktoberfest/">
   <picture>

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,6 @@
 ## Build great things at any scale
 
-In a nutshell, Jenkins is the leading open-source automation server. 
+In a nutshell, Jenkins is the leading open-source automation server.
 It provides over 1,800 [plugins](https://plugins.jenkins.io/) for many use cases so that humans can spend their time doing things machines cannot.
 Learn more: [Jenkins Website](https://www.jenkins.io/), [Documentation](https://www.jenkins.io/doc/), [Plugin Index](https://plugins.jenkins.io/)
 
@@ -13,3 +13,16 @@ See also our [Project Governance and Values](https://www.jenkins.io/project/gove
 This is the main GitHub organization of the Jenkins community.
 It includes repositories of the [Jenkins core](https://github.com/jenkinsci/jenkins), plugins, libraries and developer tools.
 You can learn more about the project structure on the [website](https://www.jenkins.io/participate/code/).
+
+# Hacktoberfest
+
+<a href="https://www.jenkins.io/events/hacktoberfest/">
+  <picture>
+      <source width="400" media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/13383509/192602080-715854aa-eaeb-442c-b208-9b5595a7c376.svg">
+      <img width="400" src="https://user-images.githubusercontent.com/13383509/192601744-52ccbb5e-3d51-4f07-b76d-2fc927bfacfb.svg">
+  </picture>
+</a>
+<br/>
+
+The Jenkins community is participating in Hacktoberfest again, and we are looking for contributors and maintainers who want to join us in October!  
+Click [here](https://www.jenkins.io/events/hacktoberfest/) to learn more about this year's Hacktoberfest, and how to make your contributions towards the Jenkins project 🎉


### PR DESCRIPTION
If you browse topics on GitHub, you possibly end up at the organization tab.

The change proposed adds a pointer to the updated blog posts, if we would like to add information for newbies here.