### PR TITLE
chore: add a link to search hacktoberfest repos in jenkinsci & jenkins-infra

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -26,4 +26,4 @@ You can learn more about the project structure on the [website](https://www.jenk
 <br/>
 
 The Jenkins community is participating in Hacktoberfest again, and we are looking for contributors and maintainers who want to join us in October!  
-[Learn more about this year's Hacktoberfest](https://www.jenkins.io/events/hacktoberfest/), and how to make your contributions towards the Jenkins project 🎉
+[Learn more about this year's Hacktoberfest](https://www.jenkins.io/events/hacktoberfest/), and how to make your contributions [towards the Jenkins project](https://github.com/search?q=topic%3Ahacktoberfest+org%3Ajenkins-infra+org%3Ajenkinsci+fork%3Atrue&type=repositories "repositories participating in Hacktoberfest") 🎉

--- a/profile/README.md
+++ b/profile/README.md
@@ -26,4 +26,4 @@ You can learn more about the project structure on the [website](https://www.jenk
 <br/>
 
 The Jenkins community is participating in Hacktoberfest again, and we are looking for contributors and maintainers who want to join us in October!  
-[Learn more about this year's Hacktoberfest](https://www.jenkins.io/events/hacktoberfest/), and how to make your contributions [towards the Jenkins project](https://github.com/search?q=topic%3Ahacktoberfest+org%3Ajenkins-infra+org%3Ajenkinsci+fork%3Atrue&type=repositories "repositories participating in Hacktoberfest") 🎉
+[Learn more about this year's Hacktoberfest](https://www.jenkins.io/events/hacktoberfest/), and how to make your contributions [towards the Jenkins project](https://github.com/search?o=desc&q=topic%3Ahacktoberfest+org%3Ajenkins-infra+org%3Ajenkinsci+fork%3Atrue&s=updated&type=Repositories "repositories participating in Hacktoberfest") 🎉


### PR DESCRIPTION
Add a link to a search of the repositories of jenkinsci and jenkins-infra tagged with "hacktoberfest"

Related: https://github.com/jenkins-infra/.github/pull/20

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
