### PR TITLE
Add Java version and vendor to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-report-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-report-bug.yml
@@ -17,6 +17,7 @@ body:
         ```groovy
         println("Jenkins: ${Jenkins.instance.getVersion()}")
         println("OS: ${System.getProperty('os.name')} - ${System.getProperty('os.version')}")
+        println("Java: ${System.getProperty('java.version')} - ${System.getProperty('java.vm.vendor')} (${System.getProperty('java.vm.name')})")
         println "---"
         
         Jenkins.instance.pluginManager.plugins
@@ -31,7 +32,6 @@ body:
         Jenkins: 2.326
         OS: Linux - 3.10.0-1160.45.1.el7.x86_64
         ---
-        ace-editor:1.1
         ant:1.13
         antisamy-markup-formatter:2.5
         apache-httpcomponents-client-4-api:4.5.13-1.0


### PR DESCRIPTION
Running Jenkins and plugins across different Java versions has different outcomes, e.g. warnings about the removal of the SecurityManager are only present on Java 17 onwards.
Hence, I'd like to add the Java version to the issue template to facilitate diagnosing issues or warnings.

Edit: According to the docs on jekins.io outlining how to report an issue, you are supposed to include that information in your bug report, but it never made its way into the copy/paste snippet.

And bye bye deprecated ace editor