### PR TITLE
Specify `permissions` for `cd.yaml`

### DIFF
--- a/workflow-templates/cd.yaml
+++ b/workflow-templates/cd.yaml
@@ -7,6 +7,10 @@ on:
     types:
       - completed
 
+permissions:
+  checks: read
+  contents: write
+
 jobs:
   maven-cd:
     uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v1


### PR DESCRIPTION
Fixes https://github.com/jenkins-infra/github-reusable-workflows/issues/23. Tested successfully in https://github.com/jenkinsci/secure-requester-whitelist-plugin/commit/c024d436f4da11e4847a442ca2a06d4c9e561575. CC @lemeurherve @timja 

See also #84 @daniel-beck.