### PR TITLE
profile readme - adding 2023 award nominees

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -16,15 +16,16 @@ You can learn more about the project structure on the [website](https://www.jenk
 
 ### Jenkins Contributor Awards 2023
 
-The annual Jenkins awards are happening now! It recognizes contributions from individuals in the community and the progress made in the name of Jenkins. You can vote by filling out the [Google form](https://docs.google.com/forms/d/e/1FAIpQLScUL4GAL-6wOjHKbT86ptKSStnglKM9_MKTQXzjgwimCDEtGw/viewform).
+The annual Jenkins awards are happening now! It recognizes contributions from individuals in the community and the progress made in the name of Jenkins.
+Vote now by filling out [this Google form](https://docs.google.com/forms/d/e/1FAIpQLScUL4GAL-6wOjHKbT86ptKSStnglKM9_MKTQXzjgwimCDEtGw/viewform)!
 
-Candidatess are:
-- Most Valuable Jenkins Advocate → [Kris Stern](https://github.com/krisstern), [Alexander Brandes](https://github.com/NotMyFault), [Bruno Verachten](https://github.com/gounthar), [Alex Earl](https://github.com/slide), [Jean-Marc Meessen](https://github.com/jmMeessen), and [Mark Waite](https://github.com/MarkEWaite)
-[Voting is open](https://github.com/jenkins-infra/jenkins.io/issues/6035)
-- Most Valuable Jenkins Contributor → [Damien Duportal](https://github.com/dduportal), [Alexander Brandes](https://github.com/NotMyFault), and [Jan Faracik](https://github.com/janfaracik)
-[Voting is open](https://github.com/jenkins-infra/jenkins.io/issues/6033)
-- Jenkins Security MVP → [Damien Duportal](https://github.com/dduportal), [Devin Nusbaum](https://github.com/dwnusbaum), [Daniel Beck](https://github.com/daniel-beck), [Valdes Che Zogou](https://github.com/ValdesChe), and [Kevin Guerroudj](https://github.com/Kevin-CB)
-[Voting is open](https://github.com/jenkins-infra/jenkins.io/issues/6034)
+Nominated candidates are:
+- [Most Valuable Jenkins Advocate](https://github.com/jenkins-infra/jenkins.io/issues/6035) → [Alex Earl](https://github.com/slide), [Alexander Brandes](https://github.com/NotMyFault), [Bruno Verachten](https://github.com/gounthar), [Jean-Marc Meessen](https://github.com/jmMeessen), [Kris Stern](https://github.com/krisstern) and [Mark Waite](https://github.com/MarkEWaite): 
+[Voting is open](https://docs.google.com/forms/d/e/1FAIpQLScUL4GAL-6wOjHKbT86ptKSStnglKM9_MKTQXzjgwimCDEtGw/viewform)
+- [Most Valuable Jenkins Contributor ](https://github.com/jenkins-infra/jenkins.io/issues/6033)→ [Alexander Brandes](https://github.com/NotMyFault), [Damien Duportal](https://github.com/dduportal) and [Jan Faracik](https://github.com/janfaracik): 
+[Voting is open](https://docs.google.com/forms/d/e/1FAIpQLScUL4GAL-6wOjHKbT86ptKSStnglKM9_MKTQXzjgwimCDEtGw/viewform)
+- [Jenkins Security MVP](https://github.com/jenkins-infra/jenkins.io/issues/6034) → [Damien Duportal](https://github.com/dduportal), [Daniel Beck](https://github.com/daniel-beck), [Devin Nusbaum](https://github.com/dwnusbaum), [Kevin Guerroudj](https://github.com/Kevin-CB) and [Valdes Che Zogou](https://github.com/ValdesChe): 
+[Voting is open](https://docs.google.com/forms/d/e/1FAIpQLScUL4GAL-6wOjHKbT86ptKSStnglKM9_MKTQXzjgwimCDEtGw/viewform)
 
 
 Awards timeline:

--- a/profile/README.md
+++ b/profile/README.md
@@ -16,12 +16,16 @@ You can learn more about the project structure on the [website](https://www.jenk
 
 ### Jenkins Contributor Awards 2023
 
-The annual Jenkins awards is happening now! It recognizes contributions from individuals in the community and the progress made in the name of Jenkins.
+The annual Jenkins awards are happening now! It recognizes contributions from individuals in the community and the progress made in the name of Jenkins. You can vote by filling out the [Google form](https://docs.google.com/forms/d/e/1FAIpQLScUL4GAL-6wOjHKbT86ptKSStnglKM9_MKTQXzjgwimCDEtGw/viewform).
 
-Nomination categories are:
-- Most Valuable Jenkins Advocate → [Nominate Someone](https://github.com/jenkins-infra/jenkins.io/issues/6035)
-- Most Valuable Jenkins Contributor → [Nominate Someone](https://github.com/jenkins-infra/jenkins.io/issues/6033)
-- Jenkins Security MVP → [Nominate Someone](https://github.com/jenkins-infra/jenkins.io/issues/6034)
+Candidatess are:
+- Most Valuable Jenkins Advocate → [Kris Stern](https://github.com/krisstern), [Alexander Brandes](https://github.com/NotMyFault), [Bruno Verachten](https://github.com/gounthar), [Alex Earl](https://github.com/slide), [Jean-Marc Meessen](https://github.com/jmMeessen), and [Mark Waite](https://github.com/MarkEWaite)
+[Voting is open](https://github.com/jenkins-infra/jenkins.io/issues/6035)
+- Most Valuable Jenkins Contributor → [Damien Duportal](https://github.com/dduportal), [Alexander Brandes](https://github.com/NotMyFault), and [Jan Faracik](https://github.com/janfaracik)
+[Voting is open](https://github.com/jenkins-infra/jenkins.io/issues/6033)
+- Jenkins Security MVP → [Damien Duportal](https://github.com/dduportal), [Devin Nusbaum](https://github.com/dwnusbaum), [Daniel Beck](https://github.com/daniel-beck), [Valdes Che Zogou](https://github.com/ValdesChe), and [Kevin Guerroudj](https://github.com/Kevin-CB)
+[Voting is open](https://github.com/jenkins-infra/jenkins.io/issues/6034)
+
 
 Awards timeline:
 - Nominations close: Friday, March 3
@@ -29,4 +33,4 @@ Awards timeline:
 - Voting closes: Tuesday, March 28
 - Winners announced at cdCon + GitOpsCon: May 8 – 9, 2023
 
-See the [announcement blogpost](https://www.jenkins.io/blog/2023/02/23/cdf-awards/) for more details for voting and nominate candidates.
+See the [announcement blogpost](https://www.jenkins.io/blog/2023/02/23/cdf-awards/) for more details for voting.


### PR DESCRIPTION
This PR is to update and add the 2023 nominees for the Jenkins awards. Currently it shows as though nominations are still open (they have closed). The nominees are now announced and voting can begin.

- [ x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
