### PR TITLE
Add a contributing nudge field in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-report-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-report-bug.yml
@@ -92,3 +92,8 @@ body:
     attributes:
       label: Anything else?
       description: You can provide additional context below.
+
+  - type: textarea
+    attributes:
+      label: Are you interested in contributing a fix?
+      description: Indicate if this is something you would like to work on, and how we can best support you in doing so. More details [on contributing](https://github.com/jenkinsci/.github/blob/master/CONTRIBUTING.md)

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -14,3 +14,8 @@ body:
     attributes:
       label: Upstream changes
       description: Link here any upstream changes that might be relevant to this request
+
+  - type: textarea
+    attributes:
+      label: Are you interested in contributing this feature?
+      description: Indicate if this is something you would like to work on, and how we can best support you in doing so. More details [on contributing](https://github.com/jenkinsci/.github/blob/master/CONTRIBUTING.md)

--- a/.github/ISSUE_TEMPLATE/3-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/3-documentation.yml
@@ -13,3 +13,8 @@ body:
   - type: textarea
     attributes:
       label: Reference any relevant documentation, other materials or issues/pull requests that can be used for inspiration.
+
+  - type: textarea
+    attributes:
+      label: Are you interested in contributing to the documentation?
+      description: Indicate if this is something you would like to work on, and how we can best support you in doing so. More details [on contributing](https://github.com/jenkinsci/.github/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
This PR adds a contributing proposal field in the issue templates.

Inspired by https://github.com/openrewrite templates.

Feel free to suggest additional links or instructions.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
