### PR TITLE
Remove the service mention after the helpdesk link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Currently the following features are configured globally:
 
 The following channels can be used:
 
-* Helpdesk - Open an issue on the [helpdesk](https://github.com/jenkins-infra/helpdesk/) (service=`GitHub`)
+* Helpdesk - Open an issue on the [helpdesk](https://github.com/jenkins-infra/helpdesk/)
 * Mailing lists - Use the [Jenkins Infrastructure mailing list](https://groups.google.com/g/jenkins-infra)
 * GitHub - Mention [@jenkinsci/github-admins](https://github.com/orgs/jenkinsci/teams/github-admins) in pull requests or GitHub issues. Available to organization members only
 


### PR DESCRIPTION
No need for this, was added initially by minicry as the previous Jira link needed a mention about the component to use:
https://github.com/jenkinsci/.github/blob/82409a89ac6aff80d1d619c6167393ac3f07c61f/README.md?plain=1#L24
