### PR TITLE
remove "tasklist" in pull_request_template.md and replace with stock checkboxes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,6 @@ For frontend changes, include screenshots of the relevant page(s) before and aft
 For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
 -->
 
-```[tasklist]
 ### Submitter checklist
 - [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
 - [ ] Ensure that the pull request title represents the desired changelog entry
@@ -20,7 +19,6 @@ For refactoring and code cleanup changes, exercise the code before and after the
 - [ ] Link to relevant issues in GitHub or Jira
 - [ ] Link to relevant pull requests, esp. upstream and downstream changes
 - [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
-```
 
 <!--
 Put an `x` into the [ ] to show you have filled the information.


### PR DESCRIPTION
the ```[tasklist] caused the tasklist to be rendered as code in preview, and has often been broken this passed week.

checkboxes work, so just replace the tasklist with them.

e.g. use the preview on the existing file https://github.com/jenkinsci/.github/blob/ba0b88f732b4f48ed84c583524e2345427cd3f0c/.github/pull_request_template.md#testing-done

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
