### PR TITLE
Update java-version to 17 for Jenkins Security Scan

### DIFF
--- a/workflow-templates/jenkins-security-scan.yaml
+++ b/workflow-templates/jenkins-security-scan.yaml
@@ -16,5 +16,5 @@ jobs:
   security-scan:
     uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
     with:
-      java-cache: '' # Optionally enable use of a build dependency cache. Specify 'maven' or 'gradle' as appropriate.
-      java-version: 11 # What version of Java to set up for the build.
+      java-cache: 'maven' # Optionally enable use of a build dependency cache. Specify 'maven' or 'gradle' as appropriate.
+      java-version: 17 # What version of Java to set up for the build.


### PR DESCRIPTION
With https://github.com/jenkinsci/jenkins/pull/9358 in effect, it makes sense to upgrade the action to run with Java 17.

In addition I propose to use the `maven` cache option to reduce build time.

### Testing done

None.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue