### PR TITLE
Document `java-version` to be optional

### DIFF
--- a/workflow-templates/jenkins-security-scan.yaml
+++ b/workflow-templates/jenkins-security-scan.yaml
@@ -17,4 +17,4 @@ jobs:
     uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
     with:
       java-cache: 'maven' # Optionally enable use of a build dependency cache. Specify 'maven' or 'gradle' as appropriate.
-      java-version: 17 # What version of Java to set up for the build.
+      java-version: 17 # Optionally specify what version of Java to set up for the build, or remove to use a recent default.


### PR DESCRIPTION
Downstream from https://github.com/jenkins-infra/jenkins-security-scan/pull/30.

We can also comment it out by default, or remove entirely. I have no preference.

Once this is merged, I will propose the same change to https://github.com/jenkinsci/archetypes/blob/master/common-files/.github/workflows/jenkins-security-scan.yml.