### PR TITLE
cd.yaml template: Enhance with validate_only config option

### DIFF
--- a/workflow-templates/cd.yaml
+++ b/workflow-templates/cd.yaml
@@ -1,8 +1,25 @@
 # Note: additional setup is required, see https://www.jenkins.io/redirect/continuous-delivery-of-plugins
-
+#
+# Please find additional hints for individual trigger use case
+# configuration options inline this script below.
+#
 name: cd
 on:
   workflow_dispatch:
+    inputs:
+      validate_only:
+        required: false
+        type: boolean
+        description: |
+          Run validation with release drafter only.
+          => Skip the release job
+        # Note: Change this default to true,
+        #       if the checkbox should be checked by default.
+        default: false
+  # If you don't want any automatic trigger in general, then
+  # the following check_run trigger lines should all be commented.
+  # Note: Consider the use case #2 config for 'validate_only' below
+  #       as an alternative option!
   check_run:
     types:
       - completed
@@ -14,6 +31,23 @@ permissions:
 jobs:
   maven-cd:
     uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v1
+    with:
+      # Comment / uncomment the validate_only config appropriate to your preference:
+      #
+      # Use case #1 (automatic release):
+      #   - Let any successful Jenkins build trigger another release,
+      #     if there are merged pull requests of interest
+      #   - Perform a validation only run with drafting a release note,
+      #     if manually triggered AND inputs.validate_only has been checked.
+      #
+      validate_only: ${{ inputs.validate_only == true }}
+      #
+      # Alternative use case #2 (no automatic release):
+      #   - Same as use case #1 - but:
+      #     - Let any check_run trigger a validate_only run.
+      #       => enforce the release job to be skipped.
+      #
+      #validate_only: ${{ inputs.validate_only == true || github.event_name == 'check_run' }}
     secrets:
       MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
       MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}

--- a/workflow-templates/cd.yaml
+++ b/workflow-templates/cd.yaml
@@ -11,8 +11,8 @@ on:
         required: false
         type: boolean
         description: |
-          Run validation with release drafter only.
-          => Skip the release job
+          Run validation with release drafter only
+          → Skip the release job
         # Note: Change this default to true,
         #       if the checkbox should be checked by default.
         default: false


### PR DESCRIPTION
@jglick @timja 

### Description
This PR is following up PR [jenkins-infra/github-reusable-workflows #32](https://github.com/jenkins-infra/github-reusable-workflows/pull/32)

The **cd.yaml** template is enhanced as follows:

- Add input selection for the manual trigger to provide the `validate_only` option of `jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml`
- Add appropriate inline help comments for individual use case config options


### Testing done
see action runs with [unleash-plugin cd.yaml](https://github.com/jenkinsci/unleash-plugin/blob/master/.github/workflows/cd.yaml):
1. automtically triggered: https://github.com/jenkinsci/unleash-plugin/actions/runs/10956424587
2. manually triggered: https://github.com/jenkinsci/unleash-plugin/actions/runs/10956762080
3. Screenshot of manual trigger start - updated after [description format improvement commit](https://github.com/jenkinsci/.github/pull/140/commits/43ccd42e301c9fb32ddd06d21e298bca704f7878):
![cd_manual_input_for_validate_only](https://github.com/user-attachments/assets/5f94eace-db55-4dad-ac9a-2052f040f0a2)


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
