### PR TITLE
Add documentation for Comment Ops and Crowdin configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Currently the following features are configured globally:
 * [Security Links](./SECURITY.md) - Automatic referencing of Jenkins security policies when creating new issues or pull requests
   ([more info](https://help.github.com/en/articles/creating-a-default-community-health-file-for-your-organization))
 * [Release Drafter](./.github/release-drafter.adoc) - Changelog automation
+* [Comment Ops](./.github/comment-ops.yml) – Enables GitHub bot commands like `/reviewer` via the [github-comment-ops](https://github.com/timja/github-comment-ops) app. Some repositories (e.g. [jenkinsci/jenkins](https://github.com/jenkinsci/jenkins/blob/master/.github/comment-ops.yml)) have additional commands such as auto-labeling enabled.
+* [Crowdin Translation Workflow](./workflow-templates/crowdin.yml) – Supports Jenkins' community translation process through Crowdin. Learn more in the [Jenkins Crowdin documentation](https://www.jenkins.io/doc/developer/crowdin/).
 
 ## Contacting Jenkins GitHub admins
 


### PR DESCRIPTION
### Summary

This pull request updates the `README.md` to include documentation for two configuration files that already exist in the repository but were not listed under the available global configurations:

- `.github/comment-ops.yml`: Enables GitHub commands like `/reviewer` through the [github-comment-ops](https://github.com/timja/github-comment-ops) app. Some repositories, like [jenkinsci/jenkins](https://github.com/jenkinsci/jenkins/blob/master/.github/comment-ops.yml), also enable additional commands like automatic labeling.

- `workflow-templates/crowdin.yml`: Defines translation workflow integration with Crowdin. Additional details are provided in the [Jenkins Crowdin documentation](https://www.jenkins.io/doc/developer/crowdin/).

These updates aim to improve clarity around which global configurations are available to Jenkins project repositories.

---

### Testing done

- Manually verified the Markdown formatting and all links.
- No code or logic was modified, so no automated testing was required.

---

### Submitter checklist
- [x] Made changes from a feature branch
- [x] PR title reflects the change made
- [x] Clearly described the change
- [x] No related GitHub issues or PRs (self-contained update)
- [x] No test applicable for a documentation-only update

Fixes #149 
